### PR TITLE
Fixes footer in Firefox

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -307,6 +307,7 @@ pre {
   }
   .site-footer .about-the-site,
   .site-footer .latest-posts {
+    -moz-box-sizing: border-box;
     box-sizing: border-box;
   }
   .site-footer .about-the-site {


### PR DESCRIPTION
I know I'm the only developer left on the planet using Firefox, but just in case it comes back into fashion soon this sorts out the footer columns dropping below each other (http://monosnap.com/image/rlCUvIGHjI36ax3hDqZ06RCRw.png).
