### PR TITLE
Add atom feed link on each page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,6 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="/img/apple-touch-icon.png" rel="apple-touch-icon" />
     <link href="/favicon.ico" rel="shortcut icon" />
+    <link href="/feed.xml" type="application/atom+xml" rel="alternate" title="The JavaScript Playground">
     <link href="//fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel="stylesheet" />
     <!-- <link href="http://jspassets.jspg.netdna-cdn.com/css/styles.css" rel="stylesheet" /> -->
     <link href="/css/styles.css" rel="stylesheet" />

--- a/feed.xml
+++ b/feed.xml
@@ -11,7 +11,7 @@ layout: none
     {% for post in site.posts limit:10 %}
     <item>
       <title>{{ post.title }}</title>
-      <description>{{ post.content | xml_escape }}</description>
+      <description type="html">{{ post.content | xml_escape }}</description>
       <pubDate>{{ post.date | date: "%a, %d %b %Y" }}</pubDate>
       <link>http://javascriptplayground.com{{ post.url }}</link>
       <guid isPermaLink="true">http://javascriptplayground.com{{ post.url }}</guid>


### PR DESCRIPTION
The atom feed was only accessible indirectly through feedburner. This also announces it to scrapers or other tools that find feeds
