### PR TITLE
Fix typo

### DIFF
--- a/_posts/2015-03-01-node-command-line-tool.md
+++ b/_posts/2015-03-01-node-command-line-tool.md
@@ -79,7 +79,7 @@ The first argument is always `node`, and the second is the path to the file that
 
 
 ```javascript
-var userArgs = process.argv.splice(2);
+var userArgs = process.argv.slice(2);
 
 var searchPattern = userArgs[0];
 ```


### PR DESCRIPTION
You must have meant [`slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice) not [`splice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice).